### PR TITLE
chore(workflow): add trigger for merge group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "dev" ]
   pull_request:
     branches: [ "main", "dev" ]
+  merge_group:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -16,6 +16,7 @@ on:
     branches: [ "main", "dev" ]
   pull_request:
     branches: [ "main", "dev" ]
+  merge_group:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflows to automatically trigger on merges to the `main` and `dev` branches, improving responsiveness and automation in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->