### PR TITLE
refactor(task): add optional 'joinable' and 'joinableAsTeam' to TaskDTO

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -468,6 +468,12 @@ paths:
           schema:
             type: integer
             format: int64
+        - schema:
+            type: boolean
+            default: false
+          in: query
+          name: queryJoinability
+          description: Check whether current user can join this task or using one of his/her team
       responses:
         "200":
           content:
@@ -649,6 +655,12 @@ paths:
           in: query
           name: sort_order
           description: '"asc" or "desc"'
+        - schema:
+            type: boolean
+            default: false
+          in: query
+          name: queryJoinability
+          description: Check whether current user can join this task or using one of his/her team
     post:
       responses:
         "200":
@@ -1742,6 +1754,13 @@ components:
           x-stoplight:
             id: ish0wypndvdar
           format: int64
+        joinable:
+          type: boolean
+          description: 'Only has value when: ''queryJoinablity'' == true'
+        joinableAsTeam:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamSummary'
     TaskSubmitterType:
       title: TaskSubmitterType
       x-stoplight:
@@ -1901,6 +1920,31 @@ components:
                 id: 9ijkfpj25gbr7
               items:
                 $ref: "#/components/schemas/User"
+    TeamSummary:
+      title: TeamSummary
+      type: object
+      required:
+        - id
+        - name
+        - intro
+        - avatarId
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        intro:
+          type: string
+        avatarId:
+          type: integer
+          format: int64
+        updatedAt:
+          type: integer
+          format: int64
+        createdAt:
+          type: integer
+          format: int64
     TaskParticipantSummary:
       title: TaskParticipantSummary
       type: object

--- a/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
@@ -73,8 +73,8 @@ class TaskController(
     }
 
     @Guard("query", "task")
-    override fun getTask(@ResourceId taskId: Long): ResponseEntity<GetTask200ResponseDTO> {
-        val taskDTO = taskService.getTaskDto(taskId)
+    override fun getTask(@ResourceId taskId: Long, queryJoinability: Boolean): ResponseEntity<GetTask200ResponseDTO> {
+        val taskDTO = taskService.getTaskDto(taskId, queryJoinability)
         return ResponseEntity.ok(GetTask200ResponseDTO(200, GetTask200ResponseDataDTO(taskDTO), "OK"))
     }
 
@@ -127,7 +127,8 @@ class TaskController(
             pageSize: Int,
             pageStart: Long?,
             sortBy: String,
-            sortOrder: String
+            sortOrder: String,
+            queryJoinability: Boolean
     ): ResponseEntity<GetTasks200ResponseDTO> {
         val by =
                 when (sortBy) {
@@ -150,7 +151,7 @@ class TaskController(
                         pageStart = pageStart,
                         sortBy = by,
                         sortOrder = order,
-                )
+                        queryJoinability = queryJoinability)
         return ResponseEntity.ok(GetTasks200ResponseDTO(200, GetTasks200ResponseDataDTO(taskSummaryDTOs, page), "OK"))
     }
 

--- a/src/main/kotlin/org/rucca/cheese/team/TeamService.kt
+++ b/src/main/kotlin/org/rucca/cheese/team/TeamService.kt
@@ -70,6 +70,19 @@ class TeamService(
         return relations.map { getTeamDto(it.team!!.id!!) }
     }
 
+    fun getTeamsThatUserCanUseToJoinTask(taskId: IdType, userId: IdType): List<TeamSummaryDTO> {
+        return teamUserRelationRepository.getTeamsThatUserCanUseToJoinTask(taskId, userId).map {
+            TeamSummaryDTO(
+                    id = it.id!!,
+                    name = it.name!!,
+                    intro = it.description!!,
+                    avatarId = it.avatar!!.id!!.toLong(),
+                    updatedAt = it.updatedAt!!.toEpochMilli(),
+                    createdAt = it.createdAt!!.toEpochMilli(),
+            )
+        }
+    }
+
     fun isTeamAdmin(teamId: IdType, userId: IdType): Boolean {
         val relationOptional = teamUserRelationRepository.findByTeamIdAndUserId(teamId, userId)
         return relationOptional.isPresent &&

--- a/src/main/kotlin/org/rucca/cheese/team/TeamUserRelationEntity.kt
+++ b/src/main/kotlin/org/rucca/cheese/team/TeamUserRelationEntity.kt
@@ -8,6 +8,7 @@ import org.rucca.cheese.common.persistent.IdType
 import org.rucca.cheese.user.User
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 enum class TeamMemberRole {
     OWNER,
@@ -45,4 +46,24 @@ interface TeamUserRelationRepository : JpaRepository<TeamUserRelation, IdType> {
             role: TeamMemberRole,
             pageable: Pageable,
     ): List<TeamUserRelation>
+
+    @Query(
+            """
+            SELECT team
+            FROM Team team
+            JOIN TeamUserRelation relation ON team.id = relation.team.id
+            WHERE relation.user.id = :userId
+            AND relation.role = :joinableIfRole
+            AND NOT EXISTS (
+                SELECT 1
+                FROM TaskMembership membership
+                WHERE membership.task.id = :taskId
+                AND membership.memberId = team.id
+            )
+            """)
+    fun getTeamsThatUserCanUseToJoinTask(
+            taskId: IdType,
+            userId: IdType,
+            joinableIfRole: TeamMemberRole = TeamMemberRole.OWNER
+    ): List<Team>
 }

--- a/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
+++ b/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
@@ -273,6 +273,48 @@ constructor(
     }
 
     @Test
+    @Order(25)
+    fun testGetTeamTaskWithJoinabilityUseTeamCreator() {
+        val taskId = taskIds[1]
+        val request =
+                MockMvcRequestBuilders.get("/tasks/$taskId")
+                        .queryParam("queryJoinability", "true")
+                        .header("Authorization", "Bearer $teamCreatorToken")
+        mockMvc.perform(request)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinable").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinableAsTeam[0].id").value(teamId))
+    }
+
+    @Test
+    @Order(26)
+    fun testGetTeamTaskWithJoinabilityUseSpaceCreator() {
+        val taskId = taskIds[1]
+        val request =
+                MockMvcRequestBuilders.get("/tasks/$taskId")
+                        .queryParam("queryJoinability", "true")
+                        .header("Authorization", "Bearer $spaceCreatorToken")
+        mockMvc.perform(request)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinable").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinableAsTeam").isEmpty)
+    }
+
+    @Test
+    @Order(27)
+    fun testGetUserTaskWithJoinabilityUseSpaceCreator() {
+        val taskId = taskIds[0]
+        val request =
+                MockMvcRequestBuilders.get("/tasks/$taskId")
+                        .queryParam("queryJoinability", "true")
+                        .header("Authorization", "Bearer $spaceCreatorToken")
+        mockMvc.perform(request)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinable").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinableAsTeam").doesNotExist())
+    }
+
+    @Test
     @Order(30)
     fun testUpdateTaskWithEmptyRequest() {
         val taskId = taskIds[0]
@@ -474,6 +516,20 @@ constructor(
     }
 
     @Test
+    @Order(106)
+    fun testGetTeamTaskWithJoinabilityUseTeamCreatorAfterJoin() {
+        val taskId = taskIds[1]
+        val request =
+                MockMvcRequestBuilders.get("/tasks/$taskId")
+                        .queryParam("queryJoinability", "true")
+                        .header("Authorization", "Bearer $teamCreatorToken")
+        mockMvc.perform(request)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinable").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinableAsTeam").isEmpty)
+    }
+
+    @Test
     @Order(110)
     fun testRemoveTestParticipantUser() {
         val request =
@@ -491,6 +547,20 @@ constructor(
                         .queryParam("member", teamId.toString())
                         .header("Authorization", "Bearer $teamCreatorToken")
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk)
+    }
+
+    @Test
+    @Order(25)
+    fun testGetTeamTaskWithJoinabilityUseTeamCreatorAfterExit() {
+        val taskId = taskIds[1]
+        val request =
+                MockMvcRequestBuilders.get("/tasks/$taskId")
+                        .queryParam("queryJoinability", "true")
+                        .header("Authorization", "Bearer $teamCreatorToken")
+        mockMvc.perform(request)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinable").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.task.joinableAsTeam[0].id").value(teamId))
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a `queryJoinability` parameter in API endpoints to check if users can join specific tasks or use team members.
	- Added `joinable` and `joinableAsTeam` properties in API responses to indicate joinability status.
	- New method to retrieve teams a user can join for a given task.

- **Bug Fixes**
	- Enhanced task retrieval logic to accurately reflect joinability based on user roles.

- **Tests**
	- Added new test cases to validate task retrieval and joinability for different user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->