### PR TITLE
feat(team): add owner to TeamDTO and remove owner from 'admins'

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -1831,6 +1831,7 @@ components:
         - intro
         - name
         - avatarId
+        - owner
         - admins
         - members
         - updatedAt
@@ -1854,6 +1855,8 @@ components:
           x-stoplight:
             id: u7o0iiyxuow4g
           format: int64
+        owner:
+          $ref: "#/components/schemas/User"
         admins:
           type: object
           x-stoplight:

--- a/src/main/kotlin/org/rucca/cheese/team/TeamService.kt
+++ b/src/main/kotlin/org/rucca/cheese/team/TeamService.kt
@@ -27,6 +27,7 @@ class TeamService(
                 name = team.name!!,
                 intro = team.description!!,
                 avatarId = team.avatar!!.id!!.toLong(),
+                owner = userService.getUserDto(getTeamOwner(teamId)),
                 admins =
                         TeamAdminsDTO(
                                 total = countTeamAdmins(teamId),
@@ -83,7 +84,7 @@ class TeamService(
     }
 
     fun countTeamAdmins(teamId: IdType): Int {
-        return teamUserRelationRepository.countByTeamIdAndRole(teamId, TeamMemberRole.ADMIN) + 1
+        return teamUserRelationRepository.countByTeamIdAndRole(teamId, TeamMemberRole.ADMIN)
     }
 
     fun countTeamNormalMembers(teamId: IdType): Int {
@@ -95,10 +96,9 @@ class TeamService(
                 teamUserRelationRepository.findAllByTeamIdAndRoleOrderByUpdatedAtDesc(
                         teamId,
                         TeamMemberRole.ADMIN,
-                        PageRequest.of(0, 2),
+                        PageRequest.of(0, 3),
                 )
-        return listOf(userService.getUserDto(getTeamOwner(teamId))) +
-                relations.map { userService.getUserDto(it.user!!.id!!.toLong()) }
+        return relations.map { userService.getUserDto(it.user!!.id!!.toLong()) }
     }
 
     fun getTeamMemberExamples(teamId: IdType): List<UserDTO> {

--- a/src/test/kotlin/org/rucca/cheese/api/TeamTest.kt
+++ b/src/test/kotlin/org/rucca/cheese/api/TeamTest.kt
@@ -77,10 +77,8 @@ constructor(
                         .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.name").value(teamName))
                         .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.intro").value(teamIntro))
                         .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.avatarId").value(teamAvatarId))
-                        .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(1))
-                        .andExpect(
-                                MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id")
-                                        .value(creator.userId))
+                        .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(creator.userId))
+                        .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(0))
                         .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.members.total").value(0))
         teamId =
                 JSONObject(response.andReturn().response.contentAsString)
@@ -98,8 +96,8 @@ constructor(
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.name").value(teamName))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.intro").value(teamIntro))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.avatarId").value(teamAvatarId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.members.total").value(0))
     }
 
@@ -112,9 +110,8 @@ constructor(
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].name").value(teamName))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].intro").value(teamIntro))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].avatarId").value(teamAvatarId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].admins.total").value(1))
-                .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.teams[0].admins.examples[0].id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].owner.id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].admins.total").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].members.total").value(0))
     }
 
@@ -134,9 +131,9 @@ constructor(
             """)
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(newOwner.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[1].id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(newOwner.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(creator.userId))
     }
 
     @Test
@@ -199,8 +196,8 @@ constructor(
             """)
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(3))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(newOwner.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(newOwner.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(2))
     }
 
     @Test
@@ -360,8 +357,7 @@ constructor(
                         .content("""{ "role": "OWNER" }""")
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(3))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(2))
                 .andExpect(
                         MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[?(@.id == ${newOwner.userId})]")
                                 .exists())
@@ -380,7 +376,7 @@ constructor(
                         .content("""{ "role": "ADMIN" }""")
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(4))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(3))
     }
 
     @Test
@@ -393,8 +389,8 @@ constructor(
                         .content("""{ "role": "MEMBER" }""")
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(3))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(2))
                 .andExpect(
                         MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[?(@.id == ${admin.userId})]")
                                 .exists())
@@ -422,9 +418,9 @@ constructor(
                         .header("Authorization", "Bearer $creatorToken")
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(creator.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[1].id").value(newOwner.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(newOwner.userId))
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `owner` field in the API schema to manage team ownership.
- **Bug Fixes**
	- Updated logic for counting team admins to exclude the owner from the total.
	- Adjusted pagination to allow retrieval of one additional admin.
- **Tests**
	- Modified test assertions to reflect changes in team ownership and admin counts, ensuring accurate representation of roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->