### PR TITLE
feat: new schema of TaskSubmissionDTO

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -1799,51 +1799,51 @@ components:
       title: TaskSubmission
       x-stoplight:
         id: 91u776sjgs8ok
-      type: array
-      items:
-        x-stoplight:
-          id: 99ox03zyo2o3q
-        type: object
-        required:
-          - id
-          - memberId
-          - version
-          - index
-          - createdAt
-          - updatedAt
-        properties:
-          id:
-            type: integer
-            format: int64
-          memberId:
-            type: integer
-            x-stoplight:
-              id: o4iozbl0ulowk
-            format: int64
-          version:
-            type: integer
-            x-stoplight:
-              id: 89v7nlohxnnmw
-          index:
-            type: integer
-            x-stoplight:
-              id: 4fw6y4vvhcs6w
-          createdAt:
-            type: integer
-            x-stoplight:
-              id: 9uvbde82liys1
-            format: int64
-          updatedAt:
-            type: integer
-            x-stoplight:
-              id: v075zyxrwkxxg
-            format: int64
-          contentText:
-            type: string
-            x-stoplight:
-              id: 3jylp7lpjh288
-          contentAttachment:
-            $ref: "#/components/schemas/Attachment"
+      type: object
+      required:
+        - id
+        - memberId
+        - version
+        - index
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        member:
+          $ref: "#/components/schemas/TaskParticipantSummary"
+        submitter:
+          $ref: "#/components/schemas/User"
+        version:
+          type: integer
+        createdAt:
+          type: integer
+          format: int64
+        updatedAt:
+          type: integer
+          format: int64
+        content:
+          type: array
+          items:
+              $ref: "#/components/schemas/TaskSubmissionContentEntry"
+    TaskSubmissionContentEntry:
+      title: TaskSubmissionContentEntry
+      type: object
+      required:
+        - title
+        - type
+      properties:
+        title:
+          type: string
+        type:
+          $ref: "#/components/schemas/TaskSubmissionType"
+        contentText:
+          type: string
+          x-stoplight:
+            id: 3jylp7lpjh288
+        contentAttachment:
+          $ref: "#/components/schemas/Attachment"
     Team:
       title: Team
       type: object

--- a/design/DB/CREATE.sql
+++ b/design/DB/CREATE.sql
@@ -86,9 +86,7 @@ CREATE
     TABLE
         attachment(
             id INTEGER NOT NULL,
-            TYPE AttachmentType NOT NULL CHECK(
-                TYPE BETWEEN 0 AND 3
-            ),
+            TYPE VARCHAR(255) NOT NULL,
             meta jsonb NOT NULL,
             url text NOT NULL,
             PRIMARY KEY(id)
@@ -178,6 +176,7 @@ CREATE
         task_submission(
             content_attachment_id INTEGER,
             INDEX INTEGER NOT NULL,
+            submitter_id INTEGER NOT NULL,
             version INTEGER NOT NULL,
             created_at TIMESTAMP(6) NOT NULL,
             deleted_at TIMESTAMP(6),
@@ -287,6 +286,9 @@ ALTER TABLE
 
 ALTER TABLE
     IF EXISTS task_submission ADD CONSTRAINT FK7p8ct6x90ypn5ubixkg9a5cf3 FOREIGN KEY(membership_id) REFERENCES task_membership;
+
+ALTER TABLE
+    IF EXISTS task_submission ADD CONSTRAINT FKgqx6epr8btfbjv5lneb6ayqu4 FOREIGN KEY(submitter_id) REFERENCES public."user";
 
 ALTER TABLE
     IF EXISTS team ADD CONSTRAINT FKjv1k745e89swu3gj896pxcq3y FOREIGN KEY(avatar_id) REFERENCES avatar;

--- a/src/main/kotlin/org/rucca/cheese/attachment/AttachmentEntity.kt
+++ b/src/main/kotlin/org/rucca/cheese/attachment/AttachmentEntity.kt
@@ -31,7 +31,29 @@ enum class AttachmentType {
     IMAGE,
     VIDEO,
     AUDIO,
-    FILE
+    FILE;
+
+    override fun toString(): String {
+        return name.lowercase()
+    }
+
+    companion object {
+        fun fromString(value: String): AttachmentType {
+            return entries.find { it.name.equals(value, ignoreCase = true) }
+                    ?: throw IllegalArgumentException("无效的 AttachmentType: $value")
+        }
+    }
+}
+
+@Converter(autoApply = true)
+class AttachmentTypeConverter : AttributeConverter<AttachmentType, String> {
+    override fun convertToDatabaseColumn(attribute: AttachmentType?): String? {
+        return attribute?.toString()
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): AttachmentType? {
+        return dbData?.let { AttachmentType.fromString(it) }
+    }
 }
 
 @Entity
@@ -47,5 +69,7 @@ open class Attachment {
 
     @JdbcTypeCode(SqlTypes.JSON) @Column(name = "meta", nullable = false) open var meta: MutableMap<String, Any>? = null
 
-    @Column(name = "type", columnDefinition = "AttachmentType", nullable = false) open var type: AttachmentType? = null
+    @Column(name = "type", nullable = false)
+    @Convert(converter = AttachmentTypeConverter::class)
+    open var type: AttachmentType? = null
 }

--- a/src/main/kotlin/org/rucca/cheese/common/Utils.kt
+++ b/src/main/kotlin/org/rucca/cheese/common/Utils.kt
@@ -1,0 +1,23 @@
+package org.rucca.cheese.common
+
+fun <T, K> List<T>.groupConsecutiveBy(keySelector: (T) -> K): List<List<T>> {
+    if (isEmpty()) return emptyList()
+
+    val result = mutableListOf<MutableList<T>>()
+    var currentGroup = mutableListOf(this.first())
+    var currentKey = keySelector(this.first())
+
+    for (item in this.drop(1)) {
+        val key = keySelector(item)
+        if (key == currentKey) {
+            currentGroup.add(item)
+        } else {
+            result.add(currentGroup)
+            currentGroup = mutableListOf(item)
+            currentKey = key
+        }
+    }
+    result.add(currentGroup)
+
+    return result
+}

--- a/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
@@ -197,7 +197,9 @@ class TaskController(
             postTaskSubmissionRequestInnerDTO: List<PostTaskSubmissionRequestInnerDTO>
     ): ResponseEntity<PostTaskSubmission200ResponseDTO> {
         val contents = postTaskSubmissionRequestInnerDTO.toEntryList()
-        val submissions = taskService.modifySubmission(taskId, member, version, contents)
+        val submissions =
+                taskService.modifySubmission(
+                        taskId, member, authenticationService.getCurrentUserId(), version, contents)
         return ResponseEntity.ok(
                 PostTaskSubmission200ResponseDTO(200, PostTaskSubmission200ResponseDataDTO(submissions), "OK"))
     }
@@ -243,7 +245,7 @@ class TaskController(
             postTaskSubmissionRequestInnerDTO: List<PostTaskSubmissionRequestInnerDTO>
     ): ResponseEntity<PostTaskSubmission200ResponseDTO> {
         val contents = postTaskSubmissionRequestInnerDTO.toEntryList()
-        val submissions = taskService.submitTask(taskId, member, contents)
+        val submissions = taskService.submitTask(taskId, member, authenticationService.getCurrentUserId(), contents)
         return ResponseEntity.ok(
                 PostTaskSubmission200ResponseDTO(200, PostTaskSubmission200ResponseDataDTO(submissions), "OK"))
     }

--- a/src/main/kotlin/org/rucca/cheese/task/TaskEntity.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskEntity.kt
@@ -30,7 +30,7 @@ class TaskSubmissionSchema(
 @Entity
 @SQLRestriction("deleted_at IS NULL")
 @EntityListeners(TaskElasticSearchSyncListener::class)
-class Task(
+data class Task(
         @Column(nullable = false) var name: String? = null,
         @Column(nullable = false) val submitterType: TaskSubmitterType? = null,
         @JoinColumn(nullable = false) @ManyToOne(fetch = FetchType.LAZY) val creator: User? = null,

--- a/src/main/kotlin/org/rucca/cheese/task/TaskMembershipEntity.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskMembershipEntity.kt
@@ -16,8 +16,8 @@ import org.springframework.data.jpa.repository.Query
                         Index(columnList = "task_id"),
                         Index(columnList = "member_id"),
                 ])
-class TaskMembership(
-        @JoinColumn(nullable = false) @ManyToOne(fetch = FetchType.LAZY) val task: Task? = null,
+data class TaskMembership(
+        @JoinColumn(nullable = false) @ManyToOne(fetch = FetchType.EAGER) val task: Task? = null,
         @Column(nullable = false) val memberId: IdType? = null,
 ) : BaseEntity()
 

--- a/src/main/kotlin/org/rucca/cheese/task/TaskSubmissionEntity.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskSubmissionEntity.kt
@@ -1,11 +1,12 @@
 package org.rucca.cheese.task
 
 import jakarta.persistence.*
-import java.util.Optional
+import java.util.*
 import org.hibernate.annotations.SQLRestriction
 import org.rucca.cheese.attachment.Attachment
 import org.rucca.cheese.common.persistent.BaseEntity
 import org.rucca.cheese.common.persistent.IdType
+import org.rucca.cheese.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -16,15 +17,18 @@ import org.springframework.data.jpa.repository.Query
                 [
                         Index(columnList = "membership_id"),
                 ])
-class TaskSubmission(
-        @JoinColumn(nullable = false) @ManyToOne(fetch = FetchType.LAZY) val membership: TaskMembership? = null,
+data class TaskSubmission(
+        @JoinColumn(nullable = false) @ManyToOne(fetch = FetchType.EAGER) val membership: TaskMembership? = null,
         @Column(nullable = false) val version: Int? = null,
         @Column(nullable = false) val index: Int? = null,
-        val contentText: String? = null, // nullable
-        @ManyToOne(fetch = FetchType.LAZY) val contentAttachment: Attachment? = null, // nullable
+        @JoinColumn(name = "submitter_id", nullable = false)
+        @ManyToOne(fetch = FetchType.EAGER)
+        val submitter: User? = null,
+        val contentText: String? = null,
+        @ManyToOne(fetch = FetchType.EAGER) val contentAttachment: Attachment? = null, // nullable
 ) : BaseEntity()
 
-interface taskSubmissionRepository : JpaRepository<TaskSubmission, IdType> {
+interface TaskSubmissionRepository : JpaRepository<TaskSubmission, IdType> {
     fun findAllByMembershipId(membershipId: IdType): List<TaskSubmission>
 
     fun findAllByMembershipIdAndVersion(membershipId: IdType, version: Int): List<TaskSubmission>

--- a/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
+++ b/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
@@ -648,17 +648,22 @@ constructor(
                                 """
                         [
                           {
+                            "title": "Text Entry",
+                            "type": "TEXT",
                             "contentText": "This is a test submission."
                           }
                         ]
                     """)
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].memberId").value(participant.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].version").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].index").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.member.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.submitter.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.version").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].title").value("Text Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].type").value("TEXT"))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submission[0].contentText")
+                        MockMvcResultMatchers.jsonPath("$.data.submission.content[0].contentText")
                                 .value("This is a test submission."))
     }
 
@@ -675,26 +680,34 @@ constructor(
                                 """
                         [
                           {
+                            "title": "Text Entry",
+                            "type": "TEXT",
                             "contentText": "This is a test submission."
                           },
                           {
+                            "title": "Attachment Entry",
+                            "type": "FILE",
                             "contentAttachmentId": $attachmentId
                           }
                         ]
                     """)
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].memberId").value(teamId.toString()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].version").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].index").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.member.id").value(teamId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.submitter.id").value(teamCreator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.version").value(1))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].title").value("Text Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].type").value("TEXT"))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submission[0].contentText")
+                        MockMvcResultMatchers.jsonPath("$.data.submission.content[0].contentText")
                                 .value("This is a test submission."))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[1].memberId").value(teamId.toString()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[1].version").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[1].index").value(1))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submission[1].contentAttachment.id").value(attachmentId))
+                        MockMvcResultMatchers.jsonPath("$.data.submission.content[1].title").value("Attachment Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[1].type").value("FILE"))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath("$.data.submission.content[1].contentAttachment.id")
+                                .value(attachmentId))
     }
 
     @Test
@@ -710,6 +723,8 @@ constructor(
                                 """
                         [
                           {
+                            "title": "Text Entry",
+                            "type": "TEXT",
                             "contentText": "This is a test submission."
                           }
                         ]
@@ -750,17 +765,22 @@ constructor(
                                 """
                         [
                           {
+                            "title": "Text Entry",
+                            "type": "TEXT",
                             "contentText": "This is a test submission. (Version 2)"
                           }
                         ]
                     """)
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].memberId").value(participant.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].version").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].index").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.member.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.submitter.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.version").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].title").value("Text Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].type").value("TEXT"))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submission[0].contentText")
+                        MockMvcResultMatchers.jsonPath("$.data.submission.content[0].contentText")
                                 .value("This is a test submission. (Version 2)"))
     }
 
@@ -777,6 +797,8 @@ constructor(
                                 """
                       [
                         {
+                          "title": "Text Entry",
+                          "type": "TEXT",
                           "contentText": "This is a test submission. (Version 1) (edited)"
                         }
                       ]
@@ -809,7 +831,7 @@ constructor(
     fun testUpdateSubmission() {
         val taskId = taskIds[0]
         val request =
-                MockMvcRequestBuilders.patch("/tasks/$taskId/submissions/1")
+                MockMvcRequestBuilders.patch("/tasks/$taskId/submissions/2")
                         .header("Authorization", "Bearer $participantToken")
                         .param("member", participant.userId.toString())
                         .contentType("application/json")
@@ -817,18 +839,23 @@ constructor(
                                 """
                       [
                         {
-                          "contentText": "This is a test submission. (Version 1) (edited)"
+                          "title": "Text Entry",
+                          "type": "TEXT",
+                          "contentText": "This is a test submission. (Version 2) (edited)"
                         }
                       ]
                     """)
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].memberId").value(participant.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].version").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission[0].index").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.member.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.submitter.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.version").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].title").value("Text Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submission.content[0].type").value("TEXT"))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submission[0].contentText")
-                                .value("This is a test submission. (Version 1) (edited)"))
+                        MockMvcResultMatchers.jsonPath("$.data.submission.content[0].contentText")
+                                .value("This is a test submission. (Version 2) (edited)"))
     }
 
     @Test
@@ -839,14 +866,16 @@ constructor(
                 MockMvcRequestBuilders.get("/tasks/$taskId/submissions").header("Authorization", "Bearer $creatorToken")
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
-                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].member.id").value(participant.userId))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].memberId").value(participant.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].version").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].index").value(0))
+                        MockMvcResultMatchers.jsonPath("$.data.submissions[0].submitter.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].version").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].title").value("Text Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].type").value("TEXT"))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].contentText")
-                                .value("This is a test submission. (Version 2)"))
+                        MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].contentText")
+                                .value("This is a test submission. (Version 2) (edited)"))
     }
 
     @Test
@@ -859,13 +888,20 @@ constructor(
                         .header("Authorization", "Bearer $creatorToken")
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].member.id").value(participant.userId))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].memberId").value(participant.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].version").value(1))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].index").value(0))
+                        MockMvcResultMatchers.jsonPath("$.data.submissions[0].submitter.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].version").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].title").value("Text Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].type").value("TEXT"))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].contentText")
-                                .value("This is a test submission. (Version 1) (edited)"))
+                        MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].contentText")
+                                .value("This is a test submission. (Version 2) (edited)"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[1].version").value(1))
+                .andExpect(
+                        MockMvcResultMatchers.jsonPath("$.data.submissions[1].content[0].contentText")
+                                .value("This is a test submission."))
     }
 
     @Test
@@ -878,13 +914,16 @@ constructor(
                         .header("Authorization", "Bearer $creatorToken")
         mockMvc.perform(request)
                 .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].id").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].member.id").value(participant.userId))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].memberId").value(participant.userId))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].version").value(2))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].index").value(0))
+                        MockMvcResultMatchers.jsonPath("$.data.submissions[0].submitter.id").value(participant.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].version").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].title").value("Text Entry"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].type").value("TEXT"))
                 .andExpect(
-                        MockMvcResultMatchers.jsonPath("$.data.submissions[0][0].contentText")
-                                .value("This is a test submission. (Version 2)"))
+                        MockMvcResultMatchers.jsonPath("$.data.submissions[0].content[0].contentText")
+                                .value("This is a test submission. (Version 2) (edited)"))
     }
 
     @Test


### PR DESCRIPTION
feat: new schema of `TaskSubmissionDTO`
fix: type field of `Attachment` entity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `TaskSubmissionContentEntry` schema for better structuring of submission content.
  - Added a method to retrieve task participant summaries by membership.
  - Enhanced task submission process by including submitter ID.

- **Bug Fixes**
  - Updated test cases to validate new JSON response structure and added error handling for non-editable submissions.

- **Refactor**
  - Changed `Task` and `TaskMembership` classes to data classes for improved functionality.
  - Modified fetch types for better data loading efficiency.
  - Streamlined submission processing logic for clarity and efficiency.

- **Chores**
  - Updated repository interface naming conventions for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->