### PR TITLE
feat(team): add 'joined' and 'role' to TeamDTO and test it

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -1860,6 +1860,7 @@ components:
         - members
         - updatedAt
         - createdAt
+        - joined
       properties:
         id:
           type: integer
@@ -1928,6 +1929,10 @@ components:
                 id: 9ijkfpj25gbr7
               items:
                 $ref: "#/components/schemas/User"
+        joined:
+          type: boolean
+        role:
+            $ref: '#/components/schemas/TeamMemberRoleType'
     TeamSummary:
       title: TeamSummary
       type: object

--- a/src/test/kotlin/org/rucca/cheese/api/TeamTest.kt
+++ b/src/test/kotlin/org/rucca/cheese/api/TeamTest.kt
@@ -80,6 +80,8 @@ constructor(
                         .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(creator.userId))
                         .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(0))
                         .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.members.total").value(0))
+                        .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.joined").value(true))
+                        .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.role").value("OWNER"))
         teamId =
                 JSONObject(response.andReturn().response.contentAsString)
                         .getJSONObject("data")
@@ -99,6 +101,8 @@ constructor(
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(creator.userId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.members.total").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.joined").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.role").value("OWNER"))
     }
 
     @Test
@@ -113,6 +117,8 @@ constructor(
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].owner.id").value(creator.userId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].admins.total").value(0))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].members.total").value(0))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].joined").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.teams[0].role").value("OWNER"))
     }
 
     @Test
@@ -134,6 +140,8 @@ constructor(
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(newOwner.userId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[0].id").value(creator.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.joined").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.role").value("ADMIN"))
     }
 
     @Test
@@ -198,6 +206,8 @@ constructor(
                 .andExpect(MockMvcResultMatchers.status().isOk)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.owner.id").value(newOwner.userId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.admins.total").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.joined").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.role").value("OWNER"))
     }
 
     @Test
@@ -218,6 +228,8 @@ constructor(
                 .andExpect(MockMvcResultMatchers.status().isOk)
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.members.total").value(1))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.members.examples[0].id").value(member.userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.joined").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.role").value("ADMIN"))
     }
 
     @Test
@@ -397,6 +409,26 @@ constructor(
                 .andExpect(
                         MockMvcResultMatchers.jsonPath("$.data.team.admins.examples[?(@.id == ${newOwner.userId})]")
                                 .exists())
+    }
+
+    @Test
+    @Order(148)
+    fun testGetTeamUseMember() {
+        val request = MockMvcRequestBuilders.get("/teams/$teamId").header("Authorization", "Bearer $memberToken")
+        mockMvc.perform(request)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.joined").value(true))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.role").value("MEMBER"))
+    }
+
+    @Test
+    @Order(149)
+    fun testGetTeamUseAnotherUser() {
+        val request = MockMvcRequestBuilders.get("/teams/$teamId").header("Authorization", "Bearer $anotherUserToken")
+        mockMvc.perform(request)
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.joined").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.team.role").doesNotExist())
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `joined` property to enhance team membership status in the API.
	- Updated user role information to reflect structured relationships within the team context.

- **Bug Fixes**
	- Improved the `getTeamDto` functionality to include user role and membership status.

- **Tests**
	- Expanded test coverage to validate `joined` status and user roles in team-related API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->