### PR TITLE
feat(task): implement and test 'reviewed' filter in getTaskSubmissions()

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -977,6 +977,11 @@ paths:
           name: queryReview
           description: Query task owner's review
         - schema:
+            type: boolean
+          in: query
+          name: reviewed
+          description: Only return reviewed or unreviewed submissions
+        - schema:
             type: integer
             default: 9
           in: query

--- a/src/main/kotlin/org/rucca/cheese/api/TasksApi.kt
+++ b/src/main/kotlin/org/rucca/cheese/api/TasksApi.kt
@@ -260,6 +260,10 @@ interface TasksApi {
         @Valid
         @RequestParam(value = "queryReview", required = false, defaultValue = "false")
         queryReview: kotlin.Boolean,
+        @Parameter(description = "Only return reviewed or unreviewed submissions")
+        @Valid
+        @RequestParam(value = "reviewed", required = false)
+        reviewed: kotlin.Boolean?,
         @Parameter(description = "Page Size", schema = Schema(defaultValue = "9"))
         @Valid
         @RequestParam(value = "page_size", required = false, defaultValue = "9")

--- a/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
@@ -129,6 +129,7 @@ class TaskController(
         @AuthInfo("member") member: Long?,
         allVersions: Boolean,
         queryReview: Boolean,
+        reviewed: Boolean?,
         pageSize: Int,
         pageStart: Long?,
         sortBy: String,
@@ -151,11 +152,12 @@ class TaskController(
                 taskId = taskId,
                 member = member,
                 allVersions = allVersions,
+                queryReview = queryReview,
+                reviewed = reviewed,
                 pageSize = pageSize,
                 pageStart = pageStart,
                 sortBy = by,
                 sortOrder = order,
-                queryReview = queryReview,
             )
         return ResponseEntity.ok(
             GetTaskSubmissions200ResponseDTO(

--- a/src/test/kotlin/org/rucca/cheese/api/TaskSubmissionReviewTest.kt
+++ b/src/test/kotlin/org/rucca/cheese/api/TaskSubmissionReviewTest.kt
@@ -174,6 +174,41 @@ constructor(
     }
 
     @Test
+    @Order(6)
+    fun testGetReviewedSubmissionWithQueryReviewEnabledWhenNotReviewed() {
+        val request =
+            MockMvcRequestBuilders.get("/tasks/$taskId/submissions")
+                .header("Authorization", "Bearer $participantToken")
+                .queryParam("member", participant.userId.toString())
+                .queryParam("queryReview", "true")
+                .queryParam("reviewed", "true")
+        mockMvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions").isEmpty)
+    }
+
+    @Test
+    @Order(7)
+    fun testGetUnreviewedSubmissionWithQueryReviewEnabledWhenNotReviewed() {
+        val request =
+            MockMvcRequestBuilders.get("/tasks/$taskId/submissions")
+                .header("Authorization", "Bearer $participantToken")
+                .queryParam("member", participant.userId.toString())
+                .queryParam("queryReview", "true")
+                .queryParam("reviewed", "false")
+        mockMvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.reviewed").value(false)
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail").doesNotExist()
+            )
+    }
+
+    @Test
     @Order(10)
     fun testCreateReview() {
         val request =
@@ -368,6 +403,49 @@ constructor(
     }
 
     @Test
+    @Order(71)
+    fun testGetReviewedSubmissionWithQueryReviewEnabled() {
+        val request =
+            MockMvcRequestBuilders.get("/tasks/$taskId/submissions")
+                .header("Authorization", "Bearer $participantToken")
+                .queryParam("member", participant.userId.toString())
+                .queryParam("queryReview", "true")
+                .queryParam("reviewed", "true")
+        mockMvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.reviewed").value(true)
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail.accepted")
+                    .value(false)
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail.score").value(4)
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail.comment")
+                    .value("Could be better.")
+            )
+    }
+
+    @Test
+    @Order(72)
+    fun testGetUnreviewedSubmissionWithQueryReviewEnabled() {
+        val request =
+            MockMvcRequestBuilders.get("/tasks/$taskId/submissions")
+                .header("Authorization", "Bearer $participantToken")
+                .queryParam("member", participant.userId.toString())
+                .queryParam("queryReview", "true")
+                .queryParam("reviewed", "false")
+        mockMvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions").isEmpty)
+    }
+
+    @Test
     @Order(75)
     fun testDeleteReviewAndGetPermissionDeniedError() {
         val request =
@@ -509,5 +587,48 @@ constructor(
                 MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail.comment")
                     .value("Good job!")
             )
+    }
+
+    @Test
+    @Order(141)
+    fun testGetReviewedSubmissionOnceAgain() {
+        val request =
+            MockMvcRequestBuilders.get("/tasks/$taskId/submissions")
+                .header("Authorization", "Bearer $participantToken")
+                .queryParam("member", participant.userId.toString())
+                .queryParam("queryReview", "true")
+                .queryParam("reviewed", "true")
+        mockMvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.reviewed").value(true)
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail.accepted")
+                    .value(true)
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail.score").value(5)
+            )
+            .andExpect(
+                MockMvcResultMatchers.jsonPath("$.data.submissions[0].review.detail.comment")
+                    .value("Good job!")
+            )
+    }
+
+    @Test
+    @Order(142)
+    fun testGetUnreviewedSubmissionOnceAgain() {
+        val request =
+            MockMvcRequestBuilders.get("/tasks/$taskId/submissions")
+                .header("Authorization", "Bearer $participantToken")
+                .queryParam("member", participant.userId.toString())
+                .queryParam("queryReview", "true")
+                .queryParam("reviewed", "false")
+        mockMvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data.submissions").isEmpty)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new query parameter `reviewed` for filtering task submissions based on their review status (reviewed/unreviewed).
  
- **Bug Fixes**
	- Streamlined the method calls by removing redundant parameters to enhance clarity.

- **Tests**
	- Added new tests to validate the retrieval of submissions based on their review status, ensuring accurate responses for both reviewed and unreviewed submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->