### PR TITLE
chore: change configuration to fix several warnings during test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
             <version>3.1.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>3.1.8</version>
+        </dependency>
     </dependencies>
 
     <!-- Build Configuration -->
@@ -280,6 +285,7 @@
                         <application.warn-audit-failure>false</application.warn-audit-failure>
                         <logging.level.root>WARN</logging.level.root>
                     </systemPropertyVariables>
+                    <argLine>-XX:+EnableDynamicAgentLoading</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,11 @@ application.legacy-url=http://localhost:3000
 application.jwt-secret=test-secret
 application.cors-origin=http://localhost:3000
 application.warn-audit-failure=true
+
+# To disable such a warning:
+# spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering.
+# Explicitly configure spring.jpa.open-in-view to disable this warning
+#
+# According to our test, disable this configuration will cause JPA to not work at all.
+# So, we enable it here.
+spring.jpa.open-in-view=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new dependency for Jersey HK2 to enhance functionality.
	- Introduced a configuration setting to enable the Open EntityManager in View pattern for improved JPA handling.

- **Bug Fixes**
	- Updated Maven Surefire Plugin configuration to support dynamic agent loading during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->