### PR TITLE
feat(tasks)!: add support for enumerating owned tasks, and enumerating approved and unapproved tasks together

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -669,6 +669,17 @@ paths:
           name: team
           description: Team ID
         - schema:
+            type: boolean
+          in: query
+          name: approved
+          description: Distinguish task status 
+        - schema:
+            type: integer
+            format: int64
+          in: query
+          name: owner
+          description: Owner's User ID
+        - schema:
             type: integer
             default: 9
           in: query
@@ -709,12 +720,6 @@ paths:
           in: query
           name: keywords
           description: Use this to search
-        - schema:
-            type: boolean
-            default: true
-          in: query
-          name: approved
-          description: Distinguish task status 
     post:
       responses:
         "200":

--- a/src/main/kotlin/org/rucca/cheese/api/TasksApi.kt
+++ b/src/main/kotlin/org/rucca/cheese/api/TasksApi.kt
@@ -320,6 +320,14 @@ interface TasksApi {
         @Valid
         @RequestParam(value = "team", required = false)
         team: kotlin.Int?,
+        @Parameter(description = "Distinguish task status")
+        @Valid
+        @RequestParam(value = "approved", required = false)
+        approved: kotlin.Boolean?,
+        @Parameter(description = "Owner's User ID")
+        @Valid
+        @RequestParam(value = "owner", required = false)
+        owner: kotlin.Long?,
         @Parameter(description = "Page Size", schema = Schema(defaultValue = "9"))
         @Valid
         @RequestParam(value = "page_size", required = false, defaultValue = "9")
@@ -358,11 +366,7 @@ interface TasksApi {
         @Parameter(description = "Use this to search")
         @Valid
         @RequestParam(value = "keywords", required = false)
-        keywords: kotlin.String?,
-        @Parameter(description = "Distinguish task status", schema = Schema(defaultValue = "true"))
-        @Valid
-        @RequestParam(value = "approved", required = false, defaultValue = "true")
-        approved: kotlin.Boolean
+        keywords: kotlin.String?
     ): ResponseEntity<GetTasks200ResponseDTO> {
         return ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
     }

--- a/src/main/kotlin/org/rucca/cheese/user/RolePermissionService.kt
+++ b/src/main/kotlin/org/rucca/cheese/user/RolePermissionService.kt
@@ -178,7 +178,8 @@ class RolePermissionService {
                                 types = listOf("task"),
                             ),
                         customLogic =
-                            "is-task-approved || is-space-admin-of-task || is-team-admin-of-task"
+                            "is-task-approved || (owned || is-enumerating-owned-tasks) " +
+                                "|| is-space-admin-of-task || is-team-admin-of-task"
                     ),
                 )
         )

--- a/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
+++ b/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
@@ -375,6 +375,19 @@ constructor(
     }
 
     @Test
+    @Order(13)
+    fun testEnumerateOwnedTasks() {
+        val request =
+            MockMvcRequestBuilders.get("/tasks")
+                .header("Authorization", "Bearer $creatorToken")
+                .param("owner", creator.userId.toString())
+        mockMvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(jsonPath("$.data.tasks.length()").value(5))
+    }
+
+    @Test
     @Order(14)
     fun testEnumerateUnapprovedTasks() {
         val request =
@@ -422,7 +435,7 @@ constructor(
             MockMvcRequestBuilders.get("/tasks/$taskId")
                 .queryParam("queryJoinability", "true")
                 .queryParam("querySubmittability", "true")
-                .header("Authorization", "Bearer $creatorToken")
+                .header("Authorization", "Bearer $participantToken")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isForbidden)
@@ -596,7 +609,9 @@ constructor(
     @Order(50)
     fun testEnumerateTasksByDefault() {
         val request =
-            MockMvcRequestBuilders.get("/tasks").header("Authorization", "Bearer $creatorToken")
+            MockMvcRequestBuilders.get("/tasks")
+                .header("Authorization", "Bearer $creatorToken")
+                .param("approved", "true")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -620,6 +635,7 @@ constructor(
             MockMvcRequestBuilders.get("/tasks")
                 .header("Authorization", "Bearer $creatorToken")
                 .param("team", teamId.toString())
+                .param("approved", "true")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -635,6 +651,7 @@ constructor(
                 .header("Authorization", "Bearer $creatorToken")
                 .param("space", spaceId.toString())
                 .param("page_size", "2")
+                .param("approved", "true")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -658,6 +675,7 @@ constructor(
                 .param("space", spaceId.toString())
                 .param("page_size", "2")
                 .param("page_start", "${taskIds[2]}")
+                .param("approved", "true")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -678,6 +696,7 @@ constructor(
                 .param("space", spaceId.toString())
                 .param("sort_by", "createdAt")
                 .param("sort_order", "asc")
+                .param("approved", "true")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -692,6 +711,7 @@ constructor(
             MockMvcRequestBuilders.get("/tasks")
                 .header("Authorization", "Bearer $creatorToken")
                 .param("keywords", taskIds[0].toString())
+                .param("approved", "true")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -706,6 +726,7 @@ constructor(
             MockMvcRequestBuilders.get("/tasks")
                 .header("Authorization", "Bearer $creatorToken")
                 .param("keywords", "$taskName (1) (updated)")
+                .param("approved", "true")
         mockMvc
             .perform(request)
             .andExpect(MockMvcResultMatchers.status().isOk)
@@ -721,6 +742,7 @@ constructor(
                 .header("Authorization", "Bearer $creatorToken")
                 .param("sort_by", "deadline")
                 .param("sort_order", "desc")
+                .param("approved", "true")
         mockMvc.perform(request).andExpect(MockMvcResultMatchers.status().isOk)
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced task filtering options with new query parameters (`approved` and `owner`) on the `/tasks` endpoint.
	- Added a `team` property requirement for task creation.
	- Introduced a search capability for teams using the `query` parameter on the `/teams` endpoint.

- **Bug Fixes**
	- Streamlined query parameters for the `/tasks` endpoint by removing redundant options.

- **Tests**
	- Added new tests for enumerating tasks by owner and updated existing tests to include the `approved` parameter for filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->