### PR TITLE
chore(ci): increase dependabot frequency to 'daily'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,19 +3,19 @@ updates:
   - package-ecosystem: 'maven'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
 
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
 
   - package-ecosystem: 'devcontainers'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated scheduling intervals for dependency checks from monthly to daily for Maven, GitHub Actions, Docker, and Devcontainers, ensuring more frequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->