### PR TITLE
feat(task): add queryJoinedApproved, queryJoinedDisapproved and queryJoinedNotApprovedOrDisapproved

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -558,6 +558,24 @@ paths:
             type: boolean
             default: false
           in: query
+          name: queryJoinedApproved
+          description: Check whether current user has joined this task and has been approved
+        - schema:
+            type: boolean
+            default: false
+          in: query
+          name: queryJoinedDisapproved
+          description: Check whether current user has joined this task and has been disapproved
+        - schema:
+            type: boolean
+            default: false
+          in: query
+          name: queryJoinedNotApprovedOrDisapproved
+          description: Check whether current user has joined this task and has not been approved or disapproved
+        - schema:
+            type: boolean
+            default: false
+          in: query
           name: queryTopics
           description: Query task's topics
       responses:
@@ -816,6 +834,24 @@ paths:
           in: query
           name: queryJoined
           description: Check whether current user has joined this task
+        - schema:
+            type: boolean
+            default: false
+          in: query
+          name: queryJoinedApproved
+          description: Check whether current user has joined this task and has been approved
+        - schema:
+            type: boolean
+            default: false
+          in: query
+          name: queryJoinedDisapproved
+          description: Check whether current user has joined this task and has been disapproved
+        - schema:
+            type: boolean
+            default: false
+          in: query
+          name: queryJoinedNotApprovedOrDisapproved
+          description: Check whether current user has joined this task and has not been approved or disapproved
         - schema:
             type: boolean
             default: false
@@ -2248,6 +2284,24 @@ components:
         joined:
           type: boolean
         joinedAsTeam:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamSummary'
+        joinedApproved:
+          type: boolean
+        joinedApprovedAsTeam:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamSummary'
+        joinedDisapproved:
+          type: boolean
+        joinedDisapprovedAsTeam:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamSummary'
+        joinedNotApprovedOrDisapproved:
+          type: boolean
+        joinedNotApprovedOrDisapprovedAsTeam:
           type: array
           items:
             $ref: '#/components/schemas/TeamSummary'

--- a/src/main/kotlin/org/rucca/cheese/api/TasksApi.kt
+++ b/src/main/kotlin/org/rucca/cheese/api/TasksApi.kt
@@ -194,6 +194,33 @@ interface TasksApi {
         @Valid
         @RequestParam(value = "queryJoined", required = false, defaultValue = "false")
         queryJoined: kotlin.Boolean,
+        @Parameter(
+            description = "Check whether current user has joined this task and has been approved",
+            schema = Schema(defaultValue = "false")
+        )
+        @Valid
+        @RequestParam(value = "queryJoinedApproved", required = false, defaultValue = "false")
+        queryJoinedApproved: kotlin.Boolean,
+        @Parameter(
+            description =
+                "Check whether current user has joined this task and has been disapproved",
+            schema = Schema(defaultValue = "false")
+        )
+        @Valid
+        @RequestParam(value = "queryJoinedDisapproved", required = false, defaultValue = "false")
+        queryJoinedDisapproved: kotlin.Boolean,
+        @Parameter(
+            description =
+                "Check whether current user has joined this task and has not been approved or disapproved",
+            schema = Schema(defaultValue = "false")
+        )
+        @Valid
+        @RequestParam(
+            value = "queryJoinedNotApprovedOrDisapproved",
+            required = false,
+            defaultValue = "false"
+        )
+        queryJoinedNotApprovedOrDisapproved: kotlin.Boolean,
         @Parameter(description = "Query task's topics", schema = Schema(defaultValue = "false"))
         @Valid
         @RequestParam(value = "queryTopics", required = false, defaultValue = "false")
@@ -431,6 +458,33 @@ interface TasksApi {
         @Valid
         @RequestParam(value = "queryJoined", required = false, defaultValue = "false")
         queryJoined: kotlin.Boolean,
+        @Parameter(
+            description = "Check whether current user has joined this task and has been approved",
+            schema = Schema(defaultValue = "false")
+        )
+        @Valid
+        @RequestParam(value = "queryJoinedApproved", required = false, defaultValue = "false")
+        queryJoinedApproved: kotlin.Boolean,
+        @Parameter(
+            description =
+                "Check whether current user has joined this task and has been disapproved",
+            schema = Schema(defaultValue = "false")
+        )
+        @Valid
+        @RequestParam(value = "queryJoinedDisapproved", required = false, defaultValue = "false")
+        queryJoinedDisapproved: kotlin.Boolean,
+        @Parameter(
+            description =
+                "Check whether current user has joined this task and has not been approved or disapproved",
+            schema = Schema(defaultValue = "false")
+        )
+        @Valid
+        @RequestParam(
+            value = "queryJoinedNotApprovedOrDisapproved",
+            required = false,
+            defaultValue = "false"
+        )
+        queryJoinedNotApprovedOrDisapproved: kotlin.Boolean,
         @Parameter(description = "Query task's topics", schema = Schema(defaultValue = "false"))
         @Valid
         @RequestParam(value = "queryTopics", required = false, defaultValue = "false")

--- a/src/main/kotlin/org/rucca/cheese/model/TaskDTO.kt
+++ b/src/main/kotlin/org/rucca/cheese/model/TaskDTO.kt
@@ -30,6 +30,12 @@ import javax.validation.Valid
  * @param rejectReason
  * @param joined
  * @param joinedAsTeam
+ * @param joinedApproved
+ * @param joinedApprovedAsTeam
+ * @param joinedDisapproved
+ * @param joinedDisapprovedAsTeam
+ * @param joinedNotApprovedOrDisapproved
+ * @param joinedNotApprovedOrDisapprovedAsTeam
  * @param topics
  */
 data class TaskDTO(
@@ -118,6 +124,27 @@ data class TaskDTO(
     @Schema(example = "null", description = "")
     @get:JsonProperty("joinedAsTeam")
     val joinedAsTeam: kotlin.collections.List<TeamSummaryDTO>? = null,
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("joinedApproved")
+    val joinedApproved: kotlin.Boolean? = null,
+    @field:Valid
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("joinedApprovedAsTeam")
+    val joinedApprovedAsTeam: kotlin.collections.List<TeamSummaryDTO>? = null,
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("joinedDisapproved")
+    val joinedDisapproved: kotlin.Boolean? = null,
+    @field:Valid
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("joinedDisapprovedAsTeam")
+    val joinedDisapprovedAsTeam: kotlin.collections.List<TeamSummaryDTO>? = null,
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("joinedNotApprovedOrDisapproved")
+    val joinedNotApprovedOrDisapproved: kotlin.Boolean? = null,
+    @field:Valid
+    @Schema(example = "null", description = "")
+    @get:JsonProperty("joinedNotApprovedOrDisapprovedAsTeam")
+    val joinedNotApprovedOrDisapprovedAsTeam: kotlin.collections.List<TeamSummaryDTO>? = null,
     @field:Valid
     @Schema(example = "null", description = "")
     @get:JsonProperty("topics")

--- a/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
@@ -315,6 +315,9 @@ class TaskController(
         queryJoinability: Boolean,
         querySubmittability: Boolean,
         queryJoined: Boolean,
+        queryJoinedApproved: Boolean,
+        queryJoinedDisapproved: Boolean,
+        queryJoinedNotApprovedOrDisapproved: Boolean,
         queryTopics: Boolean,
     ): ResponseEntity<GetTask200ResponseDTO> {
         val queryOptions =
@@ -324,6 +327,9 @@ class TaskController(
                 queryJoinability = queryJoinability,
                 querySubmittability = querySubmittability,
                 queryJoined = queryJoined,
+                queryJoinedApproved = queryJoinedApproved,
+                queryJoinedDisapproved = queryJoinedDisapproved,
+                queryJoinedNotApprovedOrDisapproved = queryJoinedNotApprovedOrDisapproved,
                 queryTopics = queryTopics,
             )
         val taskDTO = taskService.getTaskDto(taskId, queryOptions)
@@ -410,6 +416,9 @@ class TaskController(
         queryJoinability: Boolean,
         querySubmittability: Boolean,
         queryJoined: Boolean,
+        queryJoinedApproved: Boolean,
+        queryJoinedDisapproved: Boolean,
+        queryJoinedNotApprovedOrDisapproved: Boolean,
         queryTopics: Boolean,
         keywords: String?,
     ): ResponseEntity<GetTasks200ResponseDTO> {
@@ -442,6 +451,9 @@ class TaskController(
                 queryJoinability = queryJoinability,
                 querySubmittability = querySubmittability,
                 queryJoined = queryJoined,
+                queryJoinedApproved = queryJoinedApproved,
+                queryJoinedDisapproved = queryJoinedDisapproved,
+                queryJoinedNotApprovedOrDisapproved = queryJoinedNotApprovedOrDisapproved,
                 queryTopics = queryTopics,
             )
         val (taskSummaryDTOs, page) =

--- a/src/main/kotlin/org/rucca/cheese/task/option/TaskQueryOptions.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/option/TaskQueryOptions.kt
@@ -6,6 +6,9 @@ data class TaskQueryOptions(
     val queryJoinability: Boolean,
     val querySubmittability: Boolean,
     val queryJoined: Boolean,
+    val queryJoinedApproved: Boolean,
+    val queryJoinedDisapproved: Boolean,
+    val queryJoinedNotApprovedOrDisapproved: Boolean,
     val queryTopics: Boolean,
 ) {
     companion object {
@@ -16,6 +19,9 @@ data class TaskQueryOptions(
                 queryJoinability = false,
                 querySubmittability = false,
                 queryJoined = false,
+                queryJoinedApproved = false,
+                queryJoinedDisapproved = false,
+                queryJoinedNotApprovedOrDisapproved = false,
                 queryTopics = false,
             )
 
@@ -26,6 +32,9 @@ data class TaskQueryOptions(
                 queryJoinability = true,
                 querySubmittability = true,
                 queryJoined = true,
+                queryJoinedApproved = true,
+                queryJoinedDisapproved = true,
+                queryJoinedNotApprovedOrDisapproved = true,
                 queryTopics = true,
             )
     }

--- a/src/main/kotlin/org/rucca/cheese/team/TeamEntity.kt
+++ b/src/main/kotlin/org/rucca/cheese/team/TeamEntity.kt
@@ -61,10 +61,10 @@ interface TeamRepository : JpaRepository<Team, IdType> {
         AND taskMembership.approved = :approved
         """
     )
-    fun getTeamsThatUserCanUseToSubmitTask(
+    fun getTeamsThatUserJoinedTaskAsWithApprovedType(
         taskId: IdType,
         userId: IdType,
-        approved: ApproveType = ApproveType.APPROVED,
+        approved: ApproveType,
     ): List<Team>
 
     @Query(

--- a/src/main/kotlin/org/rucca/cheese/team/TeamService.kt
+++ b/src/main/kotlin/org/rucca/cheese/team/TeamService.kt
@@ -142,15 +142,25 @@ class TeamService(
     }
 
     fun getTeamsThatUserCanUseToSubmitTask(taskId: IdType, userId: IdType): List<TeamSummaryDTO> {
-        return teamRepository.getTeamsThatUserCanUseToSubmitTask(taskId, userId).map {
-            it.toTeamSummaryDTO()
-        }
+        return teamRepository
+            .getTeamsThatUserJoinedTaskAsWithApprovedType(taskId, userId, ApproveType.APPROVED)
+            .map { it.toTeamSummaryDTO() }
     }
 
     fun getTeamsThatUserJoinedTaskAs(taskId: IdType, userId: IdType): List<TeamSummaryDTO> {
         return teamRepository.getTeamsThatUserJoinedTaskAs(taskId, userId).map {
             it.toTeamSummaryDTO()
         }
+    }
+
+    fun getTeamsThatUserJoinedTaskAsWithApprovedType(
+        taskId: IdType,
+        userId: IdType,
+        approveType: ApproveType
+    ): List<TeamSummaryDTO> {
+        return teamRepository
+            .getTeamsThatUserJoinedTaskAsWithApprovedType(taskId, userId, approveType)
+            .map { it.toTeamSummaryDTO() }
     }
 
     fun isTeamAdmin(teamId: IdType, userId: IdType): Boolean {

--- a/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
+++ b/src/test/kotlin/org/rucca/cheese/api/TaskTest.kt
@@ -598,6 +598,9 @@ constructor(
                 .queryParam("queryJoinability", "true")
                 .queryParam("querySubmittability", "true")
                 .queryParam("queryJoined", "true")
+                .queryParam("queryJoinedApproved", "true")
+                .queryParam("queryJoinedDisapproved", "true")
+                .queryParam("queryJoinedNotApprovedOrDisapproved", "true")
                 .header("Authorization", "Bearer $teamCreatorToken")
         mockMvc
             .perform(request)
@@ -610,6 +613,12 @@ constructor(
             .andExpect(jsonPath("$.data.task.submittableAsTeam").isEmpty)
             .andExpect(jsonPath("$.data.task.joined").value(false))
             .andExpect(jsonPath("$.data.task.joinedAsTeam").isEmpty)
+            .andExpect(jsonPath("$.data.task.joinedApproved").value(false))
+            .andExpect(jsonPath("$.data.task.joinedApprovedAsTeam").isEmpty)
+            .andExpect(jsonPath("$.data.task.joinedDisapproved").value(false))
+            .andExpect(jsonPath("$.data.task.joinedDisapprovedAsTeam").isEmpty)
+            .andExpect(jsonPath("$.data.task.joinedNotApprovedOrDisapproved").value(false))
+            .andExpect(jsonPath("$.data.task.joinedNotApprovedOrDisapprovedAsTeam").isEmpty)
     }
 
     @Test
@@ -1096,6 +1105,9 @@ constructor(
                 .queryParam("queryJoinability", "true")
                 .queryParam("querySubmittability", "true")
                 .queryParam("queryJoined", "true")
+                .queryParam("queryJoinedApproved", "true")
+                .queryParam("queryJoinedDisapproved", "true")
+                .queryParam("queryJoinedNotApprovedOrDisapproved", "true")
                 .header("Authorization", "Bearer $teamCreatorToken")
         mockMvc
             .perform(request)
@@ -1106,6 +1118,14 @@ constructor(
             .andExpect(jsonPath("$.data.task.submittableAsTeam").isEmpty())
             .andExpect(jsonPath("$.data.task.joined").value(true))
             .andExpect(jsonPath("$.data.task.joinedAsTeam[0].id").value(teamId))
+            .andExpect(jsonPath("$.data.task.joinedApproved").value(false))
+            .andExpect(jsonPath("$.data.task.joinedApprovedAsTeam").isEmpty)
+            .andExpect(jsonPath("$.data.task.joinedDisapproved").value(false))
+            .andExpect(jsonPath("$.data.task.joinedDisapprovedAsTeam").isEmpty)
+            .andExpect(jsonPath("$.data.task.joinedNotApprovedOrDisapproved").value(true))
+            .andExpect(
+                jsonPath("$.data.task.joinedNotApprovedOrDisapprovedAsTeam[0].id").value(teamId)
+            )
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced task filtering with new query parameters: `queryJoinedApproved`, `queryJoinedDisapproved`, and `queryJoinedNotApprovedOrDisapproved` for improved task participation management.
	- Updated `Task` and `TaskSubmission` schemas to include detailed properties reflecting user approval statuses.
	- Introduced a new method to retrieve teams based on user task participation and approval status.

- **Bug Fixes**
	- Improved error handling in task management tests to ensure appropriate messages for permission-related actions.

- **Tests**
	- Expanded test coverage for task management functionalities, including scenarios for participant approval statuses and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->