### PR TITLE
fix(task): cannot reject application after approved participant reaches limit

### DIFF
--- a/src/main/kotlin/org/rucca/cheese/task/TaskMembershipService.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskMembershipService.kt
@@ -195,7 +195,7 @@ class TaskMembershipService(
     }
 
     fun updateTaskMembershipApproved(taskId: IdType, memberId: IdType, approved: ApproveType) {
-        ensureTaskParticipantNotReachedLimit(taskId)
+        if (approved == ApproveType.APPROVED) ensureTaskParticipantNotReachedLimit(taskId)
         val participant = getTaskMembership(taskId, memberId)
         participant.approved = approved
         taskMembershipRepository.save(participant)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified logic for task membership approvals, ensuring participant limit checks are only enforced when a participant is being approved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->