### PR TITLE
feat(task): auto reject participant after reaches limit

### DIFF
--- a/src/main/kotlin/org/rucca/cheese/common/config/ApplicationConfig.kt
+++ b/src/main/kotlin/org/rucca/cheese/common/config/ApplicationConfig.kt
@@ -14,4 +14,5 @@ class ApplicationConfig {
     var rankCheckEnforced: Boolean = false
     var rankJump: Int = 1
     var enforceTaskParticipantLimitCheck: Boolean = false
+    var autoRejectParticipantAfterReachesLimit: Boolean = false
 }

--- a/src/main/kotlin/org/rucca/cheese/task/TaskMembershipEntity.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskMembershipEntity.kt
@@ -44,6 +44,8 @@ class TaskMembership(
 interface TaskMembershipRepository : JpaRepository<TaskMembership, IdType> {
     fun findAllByTaskId(taskId: IdType): List<TaskMembership>
 
+    fun findAllByTaskIdAndApproved(taskId: IdType, approved: ApproveType): List<TaskMembership>
+
     fun findByTaskIdAndMemberId(taskId: IdType, memberId: IdType): Optional<TaskMembership>
 
     fun existsByTaskIdAndMemberId(taskId: IdType, memberId: IdType): Boolean

--- a/src/main/kotlin/org/rucca/cheese/task/TaskMembershipService.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskMembershipService.kt
@@ -166,6 +166,7 @@ class TaskMembershipService(
                 realNameInfo = realNameInfo?.convert() ?: DefaultTaskMembershipRealNameInfo
             )
         )
+        autoRejectParticipantAfterReachesLimit(taskId)
     }
 
     fun updateTaskMembershipDeadline(
@@ -194,11 +195,33 @@ class TaskMembershipService(
         }
     }
 
+    fun autoRejectParticipantAfterReachesLimit(taskId: IdType) {
+        if (applicationConfig.autoRejectParticipantAfterReachesLimit) {
+            val task = getTask(taskId)
+            if (task.participantLimit != null) {
+                val actual =
+                    taskMembershipRepository.countByTaskIdAndApproved(taskId, ApproveType.APPROVED)
+                if (actual >= task.participantLimit!!) {
+                    val participants =
+                        taskMembershipRepository.findAllByTaskIdAndApproved(
+                            taskId,
+                            ApproveType.NONE
+                        )
+                    participants.forEach {
+                        it.approved = ApproveType.DISAPPROVED
+                        taskMembershipRepository.save(it)
+                    }
+                }
+            }
+        }
+    }
+
     fun updateTaskMembershipApproved(taskId: IdType, memberId: IdType, approved: ApproveType) {
         ensureTaskParticipantNotReachedLimit(taskId)
         val participant = getTaskMembership(taskId, memberId)
         participant.approved = approved
         taskMembershipRepository.save(participant)
+        autoRejectParticipantAfterReachesLimit(taskId)
     }
 
     fun updateTaskMembershipRealNameInfo(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,7 @@ application.rank-check-enforced=true
 application.rank-jump=1
 
 application.enforce-task-participant-limit-check=true
+application.auto-reject-participant-after-reaches-limit=true
 
 # To disable such a warning:
 # spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for automatic rejection of participants once a specified limit is reached.
	- Enhanced task membership querying with the ability to filter based on approval status.

- **Bug Fixes**
	- Improved handling of participant limits during task membership updates and additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->