### PR TITLE
feat(task): allow task owner to set 'approved' to NONE

### DIFF
--- a/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskController.kt
@@ -288,6 +288,18 @@ class TaskController(
                 ownerId == userId
             }
         }
+        authorizationService.customAuthLogics.register("is-modifying-approved-to-none") {
+            _: IdType,
+            _: AuthorizedAction,
+            _: String,
+            _: IdType?,
+            authInfo: Map<String, Any>,
+            _: IdGetter?,
+            _: Any?,
+            ->
+            val approved = authInfo["approved"] as? ApproveTypeDTO
+            approved == ApproveTypeDTO.NONE
+        }
     }
 
     @Guard("delete", "task")
@@ -486,7 +498,12 @@ class TaskController(
         patchTaskRequestDTO: PatchTaskRequestDTO
     ): ResponseEntity<GetTask200ResponseDTO> {
         if (patchTaskRequestDTO.approved != null) {
-            authorizationService.audit("modify-approved", "task", taskId)
+            authorizationService.audit(
+                "modify-approved",
+                "task",
+                taskId,
+                mapOf("approved" to patchTaskRequestDTO.approved)
+            )
             taskService.updateApproved(taskId, patchTaskRequestDTO.approved.convert())
         }
         if (patchTaskRequestDTO.rejectReason != null) {

--- a/src/main/kotlin/org/rucca/cheese/user/RolePermissionService.kt
+++ b/src/main/kotlin/org/rucca/cheese/user/RolePermissionService.kt
@@ -133,7 +133,8 @@ class RolePermissionService {
                                 "modify-reject-reason",
                             ),
                         authorizedResource = AuthorizedResource(types = listOf("task")),
-                        customLogic = "is-space-admin-of-task || is-team-admin-of-task"
+                        customLogic =
+                            "is-space-admin-of-task || is-team-admin-of-task || (owned && is-modifying-approved-to-none)"
                     ),
                     Permission(
                         authorizedActions =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced custom authorization logic for task modifications, enhancing security checks when approval status changes to none.
	- Updated permission logic for standard users to include nuanced checks for task modifications.

- **Bug Fixes**
	- Improved tracking of approval status changes in task modifications through enhanced audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->