### PR TITLE
chore: remove `sudo` in scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ To get started, you need to install JDK 21. Make sure you have the correct versi
 
 You also need to set up several services. We recommend using Docker to run these services. Make sure you have installed
 Docker and run ```doc/script/dependency-start.sh``` and ```doc/script/dependency-restart.sh```
-in Unix shell or the bash in Docker Desktop to start the services. (You may need to remove ```sudo``` and run the commands
-one by one manually if you want to do it on Windows in Docker Desktop)
+in Unix shell or the bash in Docker Desktop to start the services. `sudo` may be required for the scripts.
 
 ### Build
 To build the project, run ```./mvnw install``` in Unix shell or PowerShell. This will generate API interfaces from the

--- a/doc/script/dependency-delete.sh
+++ b/doc/script/dependency-delete.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-sudo systemctl start docker
-sudo docker stop elasticsearch postgres cheese_legacy
-sudo docker rm elasticsearch postgres cheese_legacy
-sudo docker network rm cheese_network
+systemctl start docker
+docker stop elasticsearch postgres cheese_legacy
+docker rm elasticsearch postgres cheese_legacy
+docker network rm cheese_network

--- a/doc/script/dependency-restart.sh
+++ b/doc/script/dependency-restart.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-sudo systemctl start docker
-sudo docker restart elasticsearch postgres cheese_legacy
+systemctl start docker
+docker restart elasticsearch postgres cheese_legacy

--- a/doc/script/dependency-start.sh
+++ b/doc/script/dependency-start.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-sudo systemctl start docker.service
+systemctl start docker.service
 
-sudo docker network create cheese_network
+docker network create cheese_network
 
-sudo docker run -d \
+docker run -d \
     --name elasticsearch \
     --network cheese_network \
     -e discovery.type=single-node \
@@ -17,7 +17,7 @@ sudo docker run -d \
     -p 9200:9200 \
     docker.elastic.co/elasticsearch/elasticsearch:8.12.1
 
-sudo docker run -d \
+docker run -d \
     --name postgres \
     --network cheese_network \
     -e POSTGRES_PASSWORD=postgres \
@@ -29,14 +29,14 @@ sudo docker run -d \
     postgres
 echo "Wait for 5 seconds please..."
 sleep 5
-sudo docker exec -i postgres bash << EOF
+docker exec -i postgres bash << EOF
     sed -i -e 's/max_connections = 100/max_connections = 1000/' /var/lib/postgresql/data/postgresql.conf
     sed -i -e 's/shared_buffers = 128MB/shared_buffers = 2GB/' /var/lib/postgresql/data/postgresql.conf
 EOF
-sudo docker restart --time 0 postgres
+docker restart --time 0 postgres
 
-sudo docker pull ghcr.io/sageseekersociety/cheese-backend-dev:dev # Update local image
-sudo docker run -d \
+docker pull ghcr.io/sageseekersociety/cheese-backend-dev:dev # Update local image
+docker run -d \
     --name cheese_legacy \
     --network cheese_network \
     -p 3000:3000 \


### PR DESCRIPTION
use `sudo ./doc/script/dependency-{action}.sh` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified guidance on the use of `sudo` for running scripts in the README file to enhance user understanding.

- **New Features**
	- Streamlined several scripts by removing `sudo` from Docker commands, allowing execution without elevated privileges while maintaining original functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->