### PR TITLE
chore: force unix line separators

### DIFF
--- a/.gitatttributes
+++ b/.gitatttributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.md text eol=lf
+*.kt text eol=lf
+*.java text eol=lf
+*.xml text eol=lf
+*.properties text eol=lf


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new `.gitattributes` file to ensure consistent text handling and line endings across various file types in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->