### PR TITLE
chore(deps): update elasticsearch image from 8.12.1 to 8.18.1 to be compatible with es sdk 8.18.1 in POM.xml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: elasticsearch:8.12.1
+    image: elasticsearch:8.18.1
     container_name: elasticsearch
     environment:
       - discovery.type=single-node


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Elasticsearch service in Docker Compose to use a newer image version (8.18.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->