### PR TITLE
feat(tasks): show task participants instead of submitters

### DIFF
--- a/design/API/NT-API.yml
+++ b/design/API/NT-API.yml
@@ -4154,7 +4154,7 @@ components:
         - intro
         - description
         - submissionSchema
-        - submitters
+        - participants
         - requireRealName
         - updatedAt
         - createdAt
@@ -4194,7 +4194,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TaskSubmissionSchemaEntry"
-        submitters:
+        participants:
           type: object
           required:
             - total
@@ -4205,13 +4205,7 @@ components:
             examples:
               type: array
               items:
-                type: object
-                required:
-                  - avatarId
-                properties:
-                  avatarId:
-                    type: integer
-                    format: int64
+                $ref: "#/components/schemas/TaskParticipantSummary"
         updatedAt:
           type: integer
           format: int64

--- a/src/main/kotlin/org/rucca/cheese/task/TaskMembershipRepository.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/TaskMembershipRepository.kt
@@ -14,6 +14,12 @@ interface TaskMembershipRepository : JpaRepository<TaskMembership, IdType> {
 
     fun findAllByTaskIdAndApproved(taskId: IdType, approved: ApproveType): List<TaskMembership>
 
+    fun findAllByTaskIdAndApproved(
+        taskId: IdType,
+        approved: ApproveType,
+        pageable: Pageable,
+    ): List<TaskMembership>
+
     fun findByTaskIdAndMemberId(taskId: IdType, memberId: IdType): Optional<TaskMembership>
 
     fun existsByTaskIdAndMemberId(taskId: IdType, memberId: IdType): Boolean

--- a/src/main/kotlin/org/rucca/cheese/task/service/TaskMembershipViewService.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/service/TaskMembershipViewService.kt
@@ -8,11 +8,14 @@ import org.rucca.cheese.common.persistent.ApproveType
 import org.rucca.cheese.common.persistent.IdType
 import org.rucca.cheese.common.persistent.convert
 import org.rucca.cheese.model.*
+import org.rucca.cheese.model.TaskSubmitterTypeDTO.TEAM
+import org.rucca.cheese.model.TaskSubmitterTypeDTO.USER
 import org.rucca.cheese.task.*
 import org.rucca.cheese.task.error.NotTaskParticipantYetError
 import org.rucca.cheese.team.TeamService
 import org.rucca.cheese.user.services.UserService
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -30,6 +33,20 @@ class TaskMembershipViewService(
     // Helper to get Task
     private fun getTask(taskId: IdType): Task {
         return taskRepository.findById(taskId).orElseThrow { NotFoundError("task", taskId) }
+    }
+
+    fun getTaskParticipantsSummary(task: Task): TaskParticipantsDTO {
+        val taskId = task.id!!
+        val total = taskMembershipRepository.countByTaskIdAndApproved(taskId, ApproveType.APPROVED)
+        val pageable = PageRequest.of(0, 3)
+        val participants =
+            taskMembershipRepository.findAllByTaskIdAndApproved(
+                taskId,
+                ApproveType.APPROVED,
+                pageable,
+            )
+        val exampleDTOs = participants.map { getParticipantSummary(task, it, false) }
+        return TaskParticipantsDTO(total = total, examples = exampleDTOs)
     }
 
     /** Assembles the detailed TaskMembershipDTO for a single participant */

--- a/src/main/kotlin/org/rucca/cheese/task/service/TaskService.kt
+++ b/src/main/kotlin/org/rucca/cheese/task/service/TaskService.kt
@@ -75,6 +75,7 @@ class TaskService(
     private val taskTopicsService: TaskTopicsService,
     private val taskMembershipService: TaskMembershipService,
     private val taskMembershipEligibilityService: TaskMembershipEligibilityService,
+    private val taskMembershipViewService: TaskMembershipViewService,
     private val userRealNameService: UserRealNameService,
     private val entityPatcher: EntityPatcher,
     private val topicService: TopicService,
@@ -275,7 +276,7 @@ class TaskService(
                             convertTaskSubmissionEntryType(it.type!!),
                         )
                     },
-            submitters = getTaskSubmittersSummary(this.id!!),
+            participants = taskMembershipViewService.getTaskParticipantsSummary(this),
             updatedAt = this.updatedAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
             createdAt = this.createdAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
             participationEligibility = participationEligibilityDto,
@@ -530,17 +531,6 @@ class TaskService(
     fun getTaskSpaceId(taskId: IdType): IdType? {
         val task = getTask(taskId)
         return task.space.id
-    }
-
-    fun getTaskSubmittersSummary(taskId: IdType): TaskSubmittersDTO {
-        val submitters = taskMembershipRepository.findByTaskIdWhereMemberHasSubmitted(taskId)
-        val examples = submitters.sortedBy { it.updatedAt }.reversed().take(3)
-        val exampleDTOs =
-            when (getTaskSumbitterType(taskId)) {
-                USER -> examples.map { userService.getUserAvatarId(it.memberId!!) }
-                TEAM -> examples.map { teamService.getTeamAvatarId(it.memberId!!) }
-            }.map { TaskSubmittersExamplesInnerDTO(it) }
-        return TaskSubmittersDTO(total = submitters.size, examples = exampleDTOs)
     }
 
     fun enumerateTasks(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Task responses now include a Participants summary with total count and up to three example participants using a standardized participant summary format.

- Refactor
  - Public API field renamed from submitters to participants in Task responses.
  - Example items for participants are now standardized participant summaries instead of inline objects.
  - API consumers should update integrations to the new field name and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->